### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that enables seamless generation of high-quality images using the Flux.1 Schnell model via Together AI. This server provides a standardized interface to specify image generation parameters.
 
+<a href="https://glama.ai/mcp/servers/y6qfizhsja">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/y6qfizhsja/badge" alt="Image Generation Server MCP server" />
+</a>
+
 ## Features
 
 - High-quality image generation powered by the Flux.1 Schnell model


### PR DESCRIPTION
This PR adds a badge for the [Image Generation MCP Server](https://glama.ai/mcp/servers/y6qfizhsja) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/y6qfizhsja">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/y6qfizhsja/badge" alt="Image Generation Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.